### PR TITLE
Add appId as a parameter to the Shopify Function

### DIFF
--- a/extensions/tokengating-function/input.graphql
+++ b/extensions/tokengating-function/input.graphql
@@ -13,7 +13,7 @@ query Input {
             id
             gates {
               id
-              configuration {
+              configuration(appId: "tokengating-example-app") {
                 id
                 metafield(namespace: "tokengating-example-app", key: "reaction") {
                   value


### PR DESCRIPTION
Following up on https://github.com/Shopify/shopify/pull/407199, we've added a way to filter gate configurations by `appId`.

Therefore, this PR updates the query to include this new parameter.