### PR TITLE
Remove noMatchingFunction method

### DIFF
--- a/extensions/tokengate-src/src/useEvaluateGate.js
+++ b/extensions/tokengate-src/src/useEvaluateGate.js
@@ -4,6 +4,7 @@ import {
 } from "@shopify/gate-context-client";
 
 // Set this to the ngrok url that is generated when you run the server
+// The url will be something like https://12345678.ngrok.io (no trailing slash or query params)
 export const host = "YOUR_NGROK_URL";
 
 if (host == "YOUR_NGROK_URL") {


### PR DESCRIPTION
This PR removes the noMatchingFunction method from the codebase.

The noMatchingFunction function was originally intended to ensure that no duplicate discounts were created when a gate was edited, mapped to the same gate configuration as an already existing discount. However, as the current version of the application does not include any editing capabilities, this method is no longer necessary and can be safely removed.

Linked Issues
This PR is linked to issue https://github.com/Shopify/tokengating-example-app/issues/16