### PR TITLE
Replace the occurrences of appId with handle

### DIFF
--- a/examples/tokengating-cart-checkout-validation/src/tests.rs
+++ b/examples/tokengating-cart-checkout-validation/src/tests.rs
@@ -24,7 +24,7 @@ fn test_errors_without_valid_gate_context() -> Result<()> {
                                             "id": "gid://shopify/GateSubject/1",
                                             "configuration": {
                                                 "id": "gid://shopify/GateConfiguration/1",
-                                                "appId": "tokengating-example-app",
+                                                "handle": "tokengating-example-app",
                                                 "metafield": {
                                                     "value": "{\"name\":\"Snowdevil exclusive\",\"type\":\"exclusive_access\",\"purchase_limit\": \"2\"}"
                                                 }
@@ -73,7 +73,7 @@ fn test_errors_with_quantity_over_limit() -> Result<()> {
                                             "id": "gid://shopify/GateSubject/1",
                                             "configuration": {
                                                 "id": "gid://shopify/GateConfiguration/1",
-                                                "appId": "tokengating-example-app",
+                                                "handle": "tokengating-example-app",
                                                 "metafield": {
                                                     "value": "{\"name\":\"Snowdevil exclusive\",\"type\":\"exclusive_access\",\"purchase_limit\": \"2\"}"
                                                 }
@@ -122,7 +122,7 @@ fn test_no_errors_valid_gate_context() -> Result<()> {
                                             "id": "gid://shopify/GateSubject/1",
                                             "configuration": {
                                                 "id": "gid://shopify/GateConfiguration/1",
-                                                "appId": "tokengating-example-app",
+                                                "handle": "tokengating-example-app",
                                                 "metafield": {
                                                     "value": "{\"name\":\"Snowdevil exclusive\",\"type\":\"exclusive_access\",\"purchase_limit\": \"2\"}"
                                                 }

--- a/extensions/tokengate/blocks/app-block.liquid
+++ b/extensions/tokengate/blocks/app-block.liquid
@@ -1,12 +1,14 @@
 <div
   id="tokengating-example-app"
   data-product_id="{{ product.id }}"
-  data-product_gated="{{ product.gated? }}">Hello world app block placeholder text
+  data-product_gated="{{ product.gated? }}"
+>
+  Hello world app block placeholder text
 </div>
 <script>
   window.myAppGates = [
     {%- for gate in product.gates -%}
-      {%- if gate.configuration.app_id == 'tokengating-example-app' -%}
+      {%- if gate.configuration.handle == 'tokengating-example-app' -%}
         {%- assign configuration = gate.configuration -%}
         {
           id: "{{ configuration.id }}",
@@ -25,10 +27,10 @@
 <script async type="module" src="{{ "index.js" | asset_url }}"></script>
 
 {% schema %}
-  {
-    "name": "Tokengate",
-    "target": "section",
-    "templates": ["product"],
-    "settings": []
-  }
+{
+  "name": "Tokengate",
+  "target": "section",
+  "templates": ["product"],
+  "settings": []
+}
 {% endschema %}

--- a/extensions/tokengating-function/input.graphql
+++ b/extensions/tokengating-function/input.graphql
@@ -11,9 +11,9 @@ query Input {
           id
           product {
             id
-            gates {
+            gates(handle: "tokengating-example-app") {
               id
-              configuration(appId: "tokengating-example-app") {
+              configuration {
                 id
                 metafield(namespace: "tokengating-example-app", key: "reaction") {
                   value

--- a/extensions/tokengating-function/src/tests.rs
+++ b/extensions/tokengating-function/src/tests.rs
@@ -24,7 +24,7 @@ fn input(
                                     "id": "gid://shopify/GateSubject/1",
                                     "configuration": {
                                         "id": "gid://shopify/GateConfiguration/1",
-                                        "appId": "tokengating-example-app",
+                                        "handle": "tokengating-example-app",
                                         "metafield": {
                                             "value": "{\"name\":\"Snowdevil discount\",\"type\":\"discount\",\"discount\":{\"type\":\"percentage\",\"value\": 25}}"
                                         }
@@ -46,7 +46,7 @@ fn input(
                                     "id": "gid://shopify/GateSubject/2",
                                     "configuration": {
                                         "id": "gid://shopify/GateConfiguration/2",
-                                        "appId": "tokengating-example-app",
+                                        "handle": "tokengating-example-app",
                                         "metafield": {
                                             "value": "{\"name\":\"Tokenfolk discount\",\"type\":\"discount\",\"discount\":{\"type\":\"amount\",\"value\": \"10\"}}"
                                         }
@@ -68,7 +68,7 @@ fn input(
                                     "id": "gid://shopify/GateSubject/3",
                                     "configuration": {
                                         "id": "gid://shopify/GateConfiguration/2",
-                                        "appId": "tokengating-example-app",
+                                        "handle": "tokengating-example-app",
                                         "metafield": {
                                             "value": "{\"name\":\"Tokenfolk discount\",\"type\":\"discount\",\"discount\":{\"type\":\"amount\",\"value\": \"10\"}}"
                                         }
@@ -90,7 +90,7 @@ fn input(
                                     "id": "gid://shopify/GateSubject/4",
                                     "configuration": {
                                         "id": "gid://shopify/GateConfiguration/3",
-                                        "appId": "tokengating-example-app",
+                                        "handle": "tokengating-example-app",
                                         "metafield": {
                                             "value": "{\"name\":\"Another discount\",\"type\":\"discount\",\"discount\":{\"type\":\"amount\",\"value\": 15}}"
                                         }

--- a/web/api/constants.js
+++ b/web/api/constants.js
@@ -1,2 +1,2 @@
-export const myAppId = "tokengating-example-app"
-export const myAppMetafieldNamespace = myAppId
+export const myHandle = "tokengating-example-app";
+export const myAppMetafieldNamespace = myHandle;

--- a/web/api/create-gate.js
+++ b/web/api/create-gate.js
@@ -1,6 +1,6 @@
 import { GraphqlQueryError } from "@shopify/shopify-api";
 import shopify from "../shopify.js";
-import { myAppMetafieldNamespace, myAppId } from "./constants.js";
+import { myAppMetafieldNamespace, myHandle } from "./constants.js";
 import { createAutomaticDiscount } from "./create-discount.js";
 
 const CREATE_GATE_CONFIGURATION_MUTATION = `
@@ -19,7 +19,7 @@ const CREATE_GATE_CONFIGURATION_MUTATION = `
           type: "json",
           value: $reaction
         }],
-        appId: "${myAppId}"
+        handle: "${myHandle}"
       }) {
       gateConfiguration {
         id

--- a/web/api/retrieve-gates.js
+++ b/web/api/retrieve-gates.js
@@ -1,15 +1,15 @@
 import { GraphqlQueryError } from "@shopify/shopify-api";
 import shopify from "../shopify.js";
 
-import { myAppMetafieldNamespace, myAppId } from "./constants.js";
+import { myAppMetafieldNamespace, myHandle } from "./constants.js";
 
 const GATES_QUERY = `
   query getGateConfigurations($first: Int!) {
-    gateConfigurations(query: "app_id:${myAppId}", first: $first) {
+    gateConfigurations(query: "handle:${myHandle}", first: $first) {
       nodes {
         id
         name
-        appId
+        handle
         requirements: metafield(namespace: "${myAppMetafieldNamespace}",
           key: "requirements") {
             value


### PR DESCRIPTION
The recommended way now to create non-unique identifiers for a group of `gateConfigurations` is to use the `handle` field instead of `appId`. Following that recommendation, the example app should reflect that to contain the most up-to-date standard.