### PR TITLE
Update `shopify_function` crate by mirroring the tutorial changes

### DIFF
--- a/extensions/tokengating-function/Cargo.toml
+++ b/extensions/tokengating-function/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tokengating-function"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
@@ -10,8 +11,8 @@ serde_json = "1.0"
 sha2 = "0.9.8"
 hmac = "0.11.0"
 hex = "0.4.3"
-shopify_function = "0.2.4"
-graphql_client = "0.12.0"
+shopify_function = "0.2.5"
+graphql_client = "0.13.0"
 
 [profile.release]
 lto = true

--- a/extensions/tokengating-function/src/main.rs
+++ b/extensions/tokengating-function/src/main.rs
@@ -114,12 +114,12 @@ fn function(input: input::ResponseData) -> Result<output::FunctionResult> {
                 gate_reaction =
                     parse_gate_reaction_from_metafield(gate_configuration.metafield.as_ref());
 
-                targets.push(output::Target {
-                    product_variant: Some(output::ProductVariantTarget {
+                targets.push(output::Target::ProductVariant(
+                    output::ProductVariantTarget {
                         id: product_variant.id.to_string(),
                         quantity: None,
-                    }),
-                });
+                    },
+                ));
             }
         }
     }
@@ -190,24 +190,15 @@ fn hmac_signature(key: &str, msg: &str) -> String {
 fn reaction_value(reaction: GateReaction) -> output::Value {
     match reaction.discount {
         Discount::Percentage { value } => {
-            return output::Value {
-                percentage: Some(output::Percentage {
-                    value: value.to_string(),
-                }),
-                fixed_amount: None,
-            }
+            return output::Value::Percentage(output::Percentage {
+                value: value.to_string(),
+            });
         }
         Discount::Amount { value } => {
-            return output::Value {
-                percentage: None,
-                fixed_amount: Some(output::FixedAmount {
-                    applies_to_each_item: None,
-                    amount: value.to_string(),
-                }),
-            }
+            return output::Value::FixedAmount(output::FixedAmount {
+                applies_to_each_item: None,
+                amount: value.to_string(),
+            });
         }
     };
 }
-
-#[cfg(test)]
-mod tests;


### PR DESCRIPTION
The `shopify_function` crate was updated to generate better types for `oneOf` directives in GraphQL. The tutorial will be updated with this change and so the example reference should also be updated. This PR updates the example reference.