### PR TITLE
Adds assetFileNames to rollupOptions and includes stylesheet in app block

### DIFF
--- a/extensions/tokengate-src/vite.config.js
+++ b/extensions/tokengate-src/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
         inlineDynamicImports: true,
         dir: "../tokengate/assets",
         entryFileNames: "index.js",
+        assetFileNames: "index.[ext]",
       },
     },
   },

--- a/extensions/tokengate/blocks/app-block.liquid
+++ b/extensions/tokengate/blocks/app-block.liquid
@@ -25,6 +25,7 @@
   Script needs to be loaded as a module to be able to use import statements.
 {% endcomment %}
 <script async type="module" src="{{ "index.js" | asset_url }}"></script>
+<link rel="stylesheet" href="{{ "index.css" | asset_url }}">
 
 {% schema %}
 {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "3.39.0",
-    "@shopify/cli": "3.39.0"
+    "@shopify/app": "3.48.1",
+    "@shopify/cli": "3.48.1"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@shopify/shopify-app-express": "^1.0.0",
-    "@shopify/shopify-app-session-storage-sqlite": "^1.0.0",
+    "@shopify/shopify-app-express": "^2.1.1",
+    "@shopify/shopify-app-session-storage-sqlite": "^1.2.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Resolves #23 

When testing locally, I ran into a few issues with `@shopify/shopify-app-express` and `@shopify/shopify-app-session-storage-sqlite` which required a unique combination of versions (see https://github.com/Shopify/shopify-app-js/issues/282).

Additionally, we were using random names in the stylesheet build while also omitting them from the liquid block which is where the errors described in #23 are rooted.