### PR TITLE
Update readme with partner support url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Requirements
 
-* This app requires a new `gates` object in Liquid that is only as early access. Please contact blockchain-partners@shopify.com with your `.myshopify.com` shop domain for access
+* This app requires a new `gates` object in Liquid that is only as early access. Please contact [Shopify Partner Support](https://help.shopify.com/en/support/partners/org-select) with your `.myshopify.com` shop domain for access
 
 ## Quick Start Guide
 


### PR DESCRIPTION
This is a small edit to change the blockchain-partners@shopify.com email address to the [authenticated partner support URL](https://help.shopify.com/en/support/partners/org-select).

This change can be safely rolled back.